### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,5 @@ Rather than pulling down binary dependencies from a package manager and extracti
 This has the downside of a (potentially very long) deploy time for the first push, with the benefit of a less-fragile build product that's somewhat less likely to break due to platform and dependency shifts. Or at least, that's the hope!
 
 ## Stack compatibility
-~~This buildpack is tested primarily against the `cedar-14` stack. Currently, a workaround is required to make it work on the newer `cedar-16` stack - see https://github.com/ello/heroku-buildpack-imagemagick/pull/17 for details.
-~~
+~~This buildpack is tested primarily against the `cedar-14` stack. Currently, a workaround is required to make it work on the newer `cedar-16` stack - see https://github.com/ello/heroku-buildpack-imagemagick/pull/17 for details.~~
 UPDATE: this buildpack supports heroku-16 stack

--- a/README.md
+++ b/README.md
@@ -9,4 +9,6 @@ Rather than pulling down binary dependencies from a package manager and extracti
 This has the downside of a (potentially very long) deploy time for the first push, with the benefit of a less-fragile build product that's somewhat less likely to break due to platform and dependency shifts. Or at least, that's the hope!
 
 ## Stack compatibility
-This buildpack is tested primarily against the `cedar-14` stack. Currently, a workaround is required to make it work on the newer `cedar-16` stack - see https://github.com/ello/heroku-buildpack-imagemagick/pull/17 for details.
+~~This buildpack is tested primarily against the `cedar-14` stack. Currently, a workaround is required to make it work on the newer `cedar-16` stack - see https://github.com/ello/heroku-buildpack-imagemagick/pull/17 for details.
+~~
+UPDATE: this buildpack supports heroku-16 stack


### PR DESCRIPTION
making it clear `heroku-16` stack is supported